### PR TITLE
Don't return couch body during del and don't add _rev by reference.

### DIFF
--- a/backbone-couch.js
+++ b/backbone-couch.js
@@ -100,9 +100,10 @@ module.exports = function(config) {
             // with a HEAD request to CouchDB.
             db.head(getUrl(model), function(err, doc) {
                 if (err) return error(err);
-                model.set({'_rev': doc._rev}, {silent: true});
-                db.del(toJSON(model), function(err, res) {
-                    err ? error(err) : success(res);
+                var attr = toJSON(model);
+                attr._rev = doc._rev;
+                db.del(attr, function(err, res) {
+                    err ? error(err) : success({});
                 })
             });
             break;


### PR DESCRIPTION
Avoid spamming backbone model with garbage properties that are return from couch after a delete like `ok: true` and `rev: xxxxxx`.

Also, no longer sets the `_rev` property directly on the model during a delete.
