### PR TITLE
Pass strictSSL: false to request

### DIFF
--- a/backbone-couch.js
+++ b/backbone-couch.js
@@ -113,6 +113,7 @@ module.exports = function(config) {
     return {
         db: db,
         install: install,
-        sync: sync
+        sync: sync,
+        request: Couch.request
     };
 };

--- a/couch.js
+++ b/couch.js
@@ -2,10 +2,6 @@ var _ = require('underscore'),
     fs = require('fs'),
     request = require('request');
 
-request.defaults({
-    strictSSL: false
-});
-
 var Couch = module.exports = function(config) {
     var host = config.host || '127.0.0.1';
     var port = config.port || (config.secure ? '6984' : '5984');
@@ -17,6 +13,7 @@ var Couch = module.exports = function(config) {
         port + '/' +
         config.name;
     this.name = config.name;
+    if (config.strictSSL === false) request.defaults({ strictSSL: false });
 };
 
 // General response parser

--- a/couch.js
+++ b/couch.js
@@ -2,6 +2,10 @@ var _ = require('underscore'),
     fs = require('fs'),
     request = require('request');
 
+request.defaults({
+    strictSSL: false
+});
+
 var Couch = module.exports = function(config) {
     var host = config.host || '127.0.0.1';
     var port = config.port || (config.secure ? '6984' : '5984');

--- a/couch.js
+++ b/couch.js
@@ -13,8 +13,9 @@ var Couch = module.exports = function(config) {
         port + '/' +
         config.name;
     this.name = config.name;
-    if (config.strictSSL === false) request.defaults({ strictSSL: false });
 };
+
+module.exports.request = request;
 
 // General response parser
 // -----------------------


### PR DESCRIPTION
Pass `strictSSL` config option through to `request` to allow CouchDB self-signed certs in Node `v0.10.x`

Refs https://github.com/mikeal/request/issues/418, https://github.com/joyent/node/issues/4984, https://github.com/joyent/node/pull/4023

/cc @yhahn @miccolis @ianshward 
